### PR TITLE
add required `raw-loader` as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mkdirp": "^0.5.0",
     "mocha": "^2.2.5",
     "npm-run-all": "^1.2.4",
+    "raw-loader": "^1.0.0",
     "rimraf": "^2.3.3",
     "should": "^7.0.4",
     "webpack": "^1.9.4"


### PR DESCRIPTION
:wave: 

The required webpack loader `raw-loader` was missing in `package.json`. I added an old version (v1) as newer ones did not work (out-of-the-box).

Thanks for this nice tool!
Markus